### PR TITLE
Modify Makefile to make to compile work and update readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-CFLAGS = -std=gnu99 -fPIC -I../lib `python-config --includes` -Wall -Wextra -O2
+CFLAGS = -std=gnu99 -fPIC -I../lib -I../src`python-config --includes` -Wall -Wextra -O2
 ifdef DEBUG
 CFLAGS += -DPYAUTH_DEBUG -O0 -ggdb3
 endif
-LIBS = `python-config --libs`
+LIBS = `python-config --libs` -lmosquitto
 DESTDIR = /usr
 
 all : auth_plugin_pyauth.so

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ current directory. Copy it under path accessible for mosquitto daemon,
 e.g.: `/usr/local/lib/mosquitto/`.
 
 ### Troubleshooting
-=======
+
 If you get errors while compiling the plugin about `-lmosquitto` then you have a missing link to libmosquitto.
 Just check the file `/usr/lib/libmosquitto.so` or `/usr/lib/mosquitto.so.1` exists and create a symlink:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ If all goes ok, there should be `auth_plugin_pyauth.so` file in the
 current directory. Copy it under path accessible for mosquitto daemon,
 e.g.: `/usr/local/lib/mosquitto/`.
 
+### Troubleshooting
+=======
+If you get errors while compiling the plugin about `-lmosquitto` then you have a missing link to libmosquitto.
+Just check the file `/usr/lib/libmosquitto.so` or `/usr/lib/mosquitto.so.1` exists and create a symlink:
+
+    ln -s /usr/lib/libmosquitto.so.1 /usr/lib/libmosquitto.so
+
+And make again the plugin. This time should work.
+
 Running
 =======
 


### PR DESCRIPTION
After testing on OSX, Ubuntu 14.04 and Debian 7 I found some missing information on both the Makefile (missing link to src folder lead to compilation errors) and to mosquitto library.

If you install from package manager, libmosquitto.so is called libmosquitto.so.1 (don't know why). Creating a symlink fixes this, but I think this should stay in the readme.

