### PR TITLE
Add the optional feature to specify module_path using mosquitto config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ to the rescue):
 
     auth_opt_pyauth_module some_module
 
-#### Optional
+### Optional
 Instead of specifying the search path for Python module in `PYTHONPATH` env variable,
     Add the following line to `mosquitto.conf`:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ to the rescue):
 
     auth_opt_pyauth_module some_module
 
-##### Optional
+#### Optional
 Instead of specifying the search path for Python module in `PYTHONPATH` env variable,
     Add the following line to `mosquitto.conf`:
 

--- a/README.md
+++ b/README.md
@@ -54,16 +54,17 @@ to the rescue):
 
     auth_opt_pyauth_module some_module
 
-Optional
-    Instead of specifying the search path for Python module in `PYTHONPATH` env variable,
+##### Optional
+Instead of specifying the search path for Python module in `PYTHONPATH` env variable,
     Add the following line to `mosquitto.conf`:
 
-        auth_opt_pyauth_module_path /home/user/module_path
+    auth_opt_pyauth_module_path /home/user/module_path
 
-    Replace /home/user/module_path with the actual module path
+   Replace /home/user/module_path with the actual module path
 
-    auth_opt_pyauth_module_path is required if mosquitto broker is run using service e.g. sudo service mosquitto start
-    service strips all environment variables including PYTHONPATH
+   `auth_opt_pyauth_module_path` is required if mosquitto broker is run using `service` e.g. sudo service mosquitto start
+
+   `service` removes all environment variables including `PYTHONPATH`
 
 Python module
 =============

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ to the rescue):
 
     auth_opt_pyauth_module some_module
 
+Optional
+    Instead of specifying the search path for Python module in `PYTHONPATH` env variable,
+    Add the following line to `mosquitto.conf`:
+
+        auth_opt_pyauth_module_path /home/user/module_path
+
+    Replace /home/user/module_path with the actual module path
+
+    auth_opt_pyauth_module_path is required if mosquitto broker is run using service e.g. sudo service mosquitto start
+    service strips all environment variables including PYTHONPATH
+
 Python module
 =============
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to the rescue):
 
 ### Optional
 Instead of specifying the search path for Python module in `PYTHONPATH` env variable,
-    Add the following line to `mosquitto.conf`:
+    add the following line to `mosquitto.conf`:
 
     auth_opt_pyauth_module_path /home/user/module_path
 

--- a/auth_plugin_pyauth.c
+++ b/auth_plugin_pyauth.c
@@ -13,6 +13,7 @@
 
 struct pyauth_data {
     char *module_name;
+    char *module_path;
     PyObject *module;
     PyObject *plugin_cleanup_func;
     PyObject *unpwd_check_func;
@@ -143,6 +144,9 @@ int mosquitto_auth_plugin_init(void **user_data, struct mosquitto_auth_opt *auth
             data->module_name = strdup(auth_opts[i].value);
             debug("pyauth_module = %s", data->module_name);
         }
+        else if (!strcmp(auth_opts[i].key, "pyauth_module_path")) {
+            data->module_path = strdup(auth_opts[i].value);
+        }
     }
     if (data->module_name == NULL)
         die(false, "pyauth_module config param missing");
@@ -157,6 +161,9 @@ int mosquitto_auth_plugin_init(void **user_data, struct mosquitto_auth_opt *auth
         die(false, "failed to initialize auxiliary module");
 #endif
 
+    if(data->module_path != NULL){
+        PySys_SetPath(data->module_path);
+    }
     data->module = PyImport_ImportModule(data->module_name);
     if (data->module == NULL)
         die(true, "failed to import module: %s", data->module_name);

--- a/auth_plugin_pyauth.c
+++ b/auth_plugin_pyauth.c
@@ -217,6 +217,7 @@ int mosquitto_auth_plugin_cleanup(void *user_data, struct mosquitto_auth_opt *au
     Py_XDECREF(data->security_cleanup_func);
     Py_XDECREF(data->psk_key_get_func);
     free(data->module_name);
+    free(data->module_path);
     free(data);
     return MOSQ_ERR_SUCCESS;
 }


### PR DESCRIPTION
Optional feature to specify module_path using mosquitto config. If mosquitto broker is run using service, then PYTHONPATH is not available. e.g. sudo service mosquitto start. The service removes all environment variables including PYTHONPATH.