### PR TITLE
Expose mosquito_log_printf function to python

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,22 @@ The module provides following function:
   function checks whether `topic` matches given `sub` pattern (for
   example, it returns `True` if `sub` is `/foo/#` and `topic` is
   `/foo/bar`) and is mostly useful is `acl_check` function above
+* `log(loglevel, message)`: log `message` into mosquitto's log
+  file with the given `loglevel` (one of the constants below).
 
 The following constants for `access` parameter in `acl_check` are
 provided:
 
 * `MOSQ_ACL_NONE`
-
 * `MOSQ_ACL_READ`
-
 * `MOSQ_ACL_WRITE`
+
+The following constants for `loglevel` parameter in `log` are provided:
+
+* `LOG_INFO`
+* `LOG_NOTICE`
+* `LOG_WARNING`
+* `LOG_ERR`
+* `LOG_DEBUG`
+* `LOG_SUBSCRIBE` (not recommended for use by plugins)
+* `LOG_UNSUBSCRIBE` (not recommended for use by plugins)

--- a/auth_plugin_pyauth.c
+++ b/auth_plugin_pyauth.c
@@ -69,9 +69,25 @@ static PyObject *pyauth_mosquitto_topic_matches_sub(PyObject *self unused, PyObj
     return PyBool_FromLong(res);
 }
 
+static PyObject *pyauth_mosquitto_log_printf(PyObject *self unused, PyObject *args)
+{
+    int loglevel;
+    char *fmt;
+
+    if (!PyArg_ParseTuple(args, "is", &loglevel, &fmt))
+    return NULL;
+
+    mosquitto_log_printf(loglevel, "%s", fmt);
+
+    Py_RETURN_NONE;
+}
+
+
 static PyMethodDef methods[] = {
     {"topic_matches_sub", pyauth_mosquitto_topic_matches_sub, METH_VARARGS,
      "Check whether a topic matches a subscription"},
+     {"log", pyauth_mosquitto_log_printf, METH_VARARGS,
+     "Log a message into mosquitto's log"},
     {NULL, NULL, 0, NULL}
 };
 
@@ -96,6 +112,15 @@ static PyObject *init_aux_module(void)
     PyModule_AddIntConstant(module, "MOSQ_ACL_NONE", MOSQ_ACL_NONE);
     PyModule_AddIntConstant(module, "MOSQ_ACL_READ", MOSQ_ACL_READ);
     PyModule_AddIntConstant(module, "MOSQ_ACL_WRITE", MOSQ_ACL_WRITE);
+
+    /* loglevel */
+    PyModule_AddIntConstant(module, "LOG_INFO", MOSQ_LOG_INFO);
+    PyModule_AddIntConstant(module, "LOG_NOTICE", MOSQ_LOG_NOTICE);
+    PyModule_AddIntConstant(module, "LOG_WARNING", MOSQ_LOG_WARNING);
+    PyModule_AddIntConstant(module, "LOG_ERR", MOSQ_LOG_ERR);
+    PyModule_AddIntConstant(module, "LOG_DEBUG", MOSQ_LOG_DEBUG);
+    PyModule_AddIntConstant(module, "LOG_SUBSCRIBE", MOSQ_LOG_SUBSCRIBE);
+    PyModule_AddIntConstant(module, "LOG_UNSUBSCRIBE", MOSQ_LOG_UNSUBSCRIBE);
 
     return module;
 }

--- a/testauth.py
+++ b/testauth.py
@@ -1,33 +1,64 @@
-from pprint import pprint
 import mosquitto_auth
 
 
 def plugin_init(opts):
-    print('plugin_init')
-    pprint(opts)
+    mosquitto_auth.log(
+        mosquitto_auth.LOG_DEBUG,
+        'plugin_init (opts: %r)' % (opts)
+    )
+
 
 def plugin_cleanup():
-    print('plugin_cleanup')
+    mosquitto_auth.log(mosquitto_auth.LOG_DEBUG, 'plugin_cleanup')
+
 
 def unpwd_check(username, password):
-    print('unpwd_check', username, password)
+    mosquitto_auth.log(
+        mosquitto_auth.LOG_DEBUG,
+        'unpwd_check (username: %s password: %s)' % (username, password)
+    )
+
     return True
+
 
 def acl_check(clientid, username, topic, access):
-    print('acl_check', mosquitto_auth.topic_matches_sub('/#', topic))
+    mosquitto_auth.log(
+        mosquitto_auth.LOG_DEBUG,
+        'acl_check %r' % (mosquitto_auth.topic_matches_sub('/#', topic))
+    )
+
     if access == mosquitto_auth.MOSQ_ACL_READ:
-        print('acl_check READ', clientid, username, topic, access)
+        mosquitto_auth.log(
+            mosquitto_auth.LOG_DEBUG,
+            'acl_check READ (clientid: %s username: %s topic: %s access: %s)'
+                % (clientid, username, topic, access)
+        )
     elif access == mosquitto_auth.MOSQ_ACL_WRITE:
-        print('acl_check WRITE', clientid, username, topic, access)
+        mosquitto_auth.log(
+            mosquitto_auth.LOG_DEBUG,
+            'acl_check WRITE (clientid: %s username: %s topic: %s access: %s)'
+                % (clientid, username, topic, access)
+        )
     return True
 
+
 def psk_key_get(identity, hint):
-    print('psk_key_get', identity, hint)
+    mosquitto_auth.log(
+        mosquitto_auth.LOG_DEBUG,
+        'psk_key_get (identity: %s hint: %s)' % (identity, hint)
+    )
     return '0123456789'
 
+
 def security_init(opts, reload):
-    print('security_init', reload)
-    pprint(opts)
+    mosquitto_auth.log(
+        mosquitto_auth.LOG_DEBUG,
+        'security_init (reload: %s, opts: %s)' % (reload, opts)
+    )
+
 
 def security_cleanup(reload):
-    print('security_cleanup', reload)
+    mosquitto_auth.log(
+        mosquitto_auth.LOG_DEBUG,
+        'security_cleanup (reload: %s)' % (reload)
+    )


### PR DESCRIPTION
This PR exposes the function `mosquitto_log_printf` for the scripts. This allows to log into Mosquitto's log with time stamps.

I've chosen to omit the `MOSQ_`prefix from the log level constants, as the constants are local to the module.